### PR TITLE
Resume 개선: 콘텐츠 + 타입 안전성 + UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1456,6 +1457,7 @@
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1516,6 +1518,7 @@
       "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -1767,6 +1770,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1984,6 +1988,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2338,6 +2343,7 @@
       "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3649,6 +3655,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -3825,6 +3832,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3834,6 +3842,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -4423,6 +4432,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4505,6 +4515,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4600,6 +4611,7 @@
       "integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -4690,6 +4702,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/public/assets/about.json
+++ b/public/assets/about.json
@@ -1,40 +1,39 @@
 {
-	"translations": {
-	  "helloText": {
-		"en": "Hello!",
-		"ko": "안녕하세요!"
-	  },
-	  "emailText": "hanguk0726@gmail.com",
-	  "githubText": "https://www.github.com/hanguk0726",
-	  "interestedText": {
-		"en": "I am especially interested in media (image, video, audio) processing and editor app development.",
-		"ko": "저는 미디어(이미지, 비디오, 오디오) 처리나 에디터 앱 개발에 특히 관심을 갖고 있습니다."
-	  },
-	  "backgroundText": {
-		"en": "I enjoy mobile engineering and I am familiar with Android native development.",
-		"ko": "저는 모바일 엔지니어링을 좋아하고 안드로이드 네이티브에 익숙합니다."
-	  },
-	  "projectText": {
-		"en": "Check out my development trace in projects like real-time video processing, reverse proxy and more. ",
-		"ko": "실시간 비디오 처리, 역방향 프록시 등의 프로젝트로 저의 개발 발자취를 확인해보세요."
-	  },
-	  "linkText": "https://medium.com/@hangukshin/building-a-video-diary-app-written-in-flutter-and-rust-without-ffmpeg-8eb97a97fb49",
-	  "contributingText": {
-		"en": "Contributing",
-		"ko": "기여"
-	  },
-	  "contributingMinimp4Text": {
-		"en": "Feature to add an audio track on mp4 muxing",
-		"ko": "mp4 muxing에 오디오 트랙을 추가하는 기능"
-	  },
-	  "contributingNokhwaText": {
-		"en": "Improving the YUV to RGB decoding logic",
-		"ko": "yuv to rgb 디코딩 로직 개선"
-	  },
-	  "linkMinimp4Text": "https://github.com/darkskygit/minimp4.rs/pull/3",
-	  "linkNokhwaText": "https://github.com/l1npengtul/nokhwa/pull/105",
-	  "linkOpenGlTextEn": "https://medium.com/@hangukshin/my-first-experience-with-a-video-editor-android-app-using-opengl-7fb88765ad0d",
-	  "linkOpenGlTextKo": "https://medium.com/@hangukshin/opengl%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%EC%98%81%EC%83%81-%ED%8E%B8%EC%A7%91-%EC%95%B1-%EB%82%98%EC%9D%98-%EC%B2%AB-%EB%8F%84%EC%A0%84%EA%B8%B0-6a686ee71c0c"
-	}
+  "translations": {
+    "helloText": {
+      "en": "Hello!",
+      "ko": "안녕하세요!"
+    },
+    "emailText": "hanguk0726@gmail.com",
+    "githubText": "https://www.github.com/hanguk0726",
+    "interestedText": {
+      "en": "I am especially interested in media (image, video, audio) processing, real-time systems, and building products from scratch.",
+      "ko": "저는 미디어(이미지, 비디오, 오디오) 처리, 실시간 시스템, 그리고 프로덕트를 처음부터 만들어내는 일에 관심을 갖고 있습니다."
+    },
+    "backgroundText": {
+      "en": "I enjoy cross-platform mobile engineering and am experienced with Android native, React Native (iOS/Android), and server infrastructure.",
+      "ko": "저는 크로스플랫폼 모바일 엔지니어링을 좋아하고, Android 네이티브, React Native(iOS/Android), 서버 인프라에 경험이 있습니다."
+    },
+    "projectText": {
+      "en": "Check out my projects spanning real-time video processing, IoT platforms, reverse proxy, and more.",
+      "ko": "실시간 비디오 처리, IoT 플랫폼, 역방향 프록시 등의 프로젝트로 저의 개발 발자취를 확인해보세요."
+    },
+    "linkText": "https://medium.com/@hangukshin/building-a-video-diary-app-written-in-flutter-and-rust-without-ffmpeg-8eb97a97fb49",
+    "contributingText": {
+      "en": "Contributing",
+      "ko": "기여"
+    },
+    "contributingMinimp4Text": {
+      "en": "Feature to add an audio track on mp4 muxing",
+      "ko": "mp4 muxing에 오디오 트랙을 추가하는 기능"
+    },
+    "contributingNokhwaText": {
+      "en": "Improving the YUV to RGB decoding logic",
+      "ko": "YUV to RGB 디코딩 로직 개선"
+    },
+    "linkMinimp4Text": "https://github.com/darkskygit/minimp4.rs/pull/3",
+    "linkNokhwaText": "https://github.com/l1npengtul/nokhwa/pull/105",
+    "linkOpenGlTextEn": "https://medium.com/@hangukshin/my-first-experience-with-a-video-editor-android-app-using-opengl-7fb88765ad0d",
+    "linkOpenGlTextKo": "https://medium.com/@hangukshin/opengl%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%EC%98%81%EC%83%81-%ED%8E%B8%EC%A7%91-%EC%95%B1-%EB%82%98%EC%9D%98-%EC%B2%AB-%EB%8F%84%EC%A0%84%EA%B8%B0-6a686ee71c0c"
   }
-  
+}

--- a/public/assets/projects.json
+++ b/public/assets/projects.json
@@ -2,23 +2,31 @@
     {
         "title": "REVITA",
         "description": {
-            "ko": "야외용 컴퓨터비전 IoT 프로젝트",
-            "en": "Outdoor Computer Vision IoT Project"
+            "ko": "컴퓨터비전 IoT 스마트팜 플랫폼",
+            "en": "Computer Vision IoT Smart Farm Platform"
         },
         "keyword": [
             "ComputerVision",
             "IoT",
+            "MQTT",
             "Pannellum",
             "OpenCV",
+            "WebRTC",
+            "HLS",
             "BackOffice",
-            "Automation"
+            "Automation",
+            "Infrastructure"
         ],
         "techStacks": [
             "React Native",
             "TypeScript",
             "Next.js",
             "OpenCV",
-            "Pannellum"
+            "Pannellum",
+            "Nginx",
+            "Airflow",
+            "MQTT",
+            "Temporal"
         ],
         "personal": false,
         "links": [],
@@ -29,8 +37,8 @@
             "endYear": null
         },
         "article": {
-            "ko": "야외용 컴퓨터비전 IoT 프로젝트에 프로덕트 엔지니어로 참여하여 모바일앱(Android, iOS), 대외용 웹사이트, 백오피스 등 전반적인 소프트웨어를 처음부터 개발했습니다.\n\n15분 이상 소요되던 파노라마 이미지 생성을 OpenCV를 활용해 2분으로 단축하고 이미지 기반 스티칭에서 영상 기반 스캔으로 전환하여 성능을 대폭 개선했습니다. 현장 파노라마를 몰입감 있게 확인할 수 있도록 웹 라이브러리 Pannellum을 모바일에 적용하고, 줌 레벨에 따른 동적 타일 요청과 정밀 촬영을 위한 좌표 마커 기능 등 커스텀 로직을 통합했습니다.\n\n백오피스에서는 GeoTIFF raster 오버레이, 컨설팅 아티클 등 반복적인 콘텐츠 생성을 자동화했습니다. 소규모 팀의 리소스 한계를 극복하기 위해 백오피스 프로젝트를 주도하여 워크플로우를 자동화하고, 누구나 다른 역할의 작업을 쉽게 수행할 수 있도록 진입장벽을 낮췄습니다.\n\n조직문화 개선 측면에서 기획·구현·전달 단계가 혼재되어 발생하던 비효율을 해소하였습니다. 또한 개인에게 의존하던 반복 작업을 워크플로우화하여 소통 비용을 줄이고 팀의 효율성과 결과물의 품질을 높였습니다.",
-            "en": "Joined as a product engineer on an outdoor computer vision IoT project, building mobile apps (Android, iOS), public-facing websites, and back-office systems from scratch.\n\nReduced panorama image generation time from over 15 minutes to 2 minutes by leveraging OpenCV, significantly improving performance. Integrated the Pannellum web library into mobile for immersive panorama viewing, adding custom features like dynamic tile requests based on zoom level and coordinate markers for precise shooting.\n\nAutomated repetitive content generation in the back-office, including GeoTIFF raster overlays and consulting articles. To overcome resource constraints in a small team, led the back-office initiative to automate workflows and lower barriers, enabling anyone to easily take on tasks across different roles.\n\nIn terms of organizational culture improvement, resolved inefficiencies caused by overlapping planning, implementation, and delivery phases. Transformed individual-dependent repetitive tasks into standardized workflows, reducing communication costs and enhancing team efficiency and output quality."
+            "ko": "컴퓨터비전 IoT 스마트팜 플랫폼에 프로덕트 엔지니어로 참여하여 모바일앱(Android, iOS), 대외용 웹사이트, 백오피스, 서버 인프라 등 전반적인 소프트웨어를 처음부터 개발했습니다.\n\n15분 이상 소요되던 파노라마 이미지 생성을 OpenCV를 활용해 2분으로 단축하고 영상 기반 스캔으로 전환하여 성능을 대폭 개선했습니다. Pannellum을 모바일에 적용하여 줌 레벨 기반 동적 타일링과 좌표 마커 등 커스텀 로직을 통합했습니다. 현장 실시간 모니터링을 위해 WebRTC/HLS 스트리밍 인프라를 구축했습니다.\n\n서버 측에서는 10개 이상의 서비스(Flask API, Next.js, Airflow, MQTT 브로커, Temporal 워크플로)를 단일 GCP VM에서 systemd로 운영하고, Nginx 리버스 프록시와 내부 CA(step-ca)로 SSL/TLS를 관리합니다. IoT 센서 데이터는 MQTT→프로세서→DB 파이프라인으로 실시간 수집되며, Airflow DAG로 데이터 파이프라인을 오케스트레이션합니다.\n\n백오피스에서는 GeoTIFF raster 오버레이, 컨설팅 아티클 등 반복적인 콘텐츠 생성을 자동화했습니다. 소규모 팀에서 워크플로우 자동화를 주도하여 진입장벽을 낮추고, 기획·구현·전달 단계의 비효율을 해소하여 팀 효율성과 결과물 품질을 높였습니다.",
+            "en": "Joined as a product engineer on a computer vision IoT smart farm platform, building mobile apps (Android, iOS), public-facing websites, back-office systems, and server infrastructure from scratch.\n\nReduced panorama image generation from 15+ minutes to 2 minutes using OpenCV with video-based scanning. Integrated Pannellum into mobile with custom features like zoom-level dynamic tiling and coordinate markers. Built WebRTC/HLS streaming infrastructure for real-time field monitoring.\n\nOn the server side, operating 10+ services (Flask API, Next.js, Airflow, MQTT broker, Temporal workflows) on a single GCP VM managed via systemd, with Nginx reverse proxy and internal CA (step-ca) for SSL/TLS. IoT sensor data flows through an MQTT→processor→DB pipeline in real-time, orchestrated by Airflow DAGs.\n\nAutomated repetitive content generation in the back-office including GeoTIFF raster overlays and consulting articles. Led workflow automation in a small team, lowering barriers and resolving inefficiencies across planning, implementation, and delivery phases to improve team efficiency and output quality."
         }
     },
     {
@@ -78,11 +86,14 @@
         "keyword": [
             "Android",
             "VideoEditor",
-            "Opengl"
+            "OpenGL",
+            "MediaCodec"
         ],
         "techStacks": [
             "Android",
-            "OpenGL"
+            "Kotlin",
+            "OpenGL",
+            "MediaCodec"
         ],
         "personal": false,
         "links": [
@@ -120,12 +131,12 @@
             "JA3-Fingerprint"
         ],
         "techStacks": [
-            "go",
-            "aerospike",
-            "clickhouse",
-            "kafka",
-            "haproxy",
-            "docker"
+            "Go",
+            "Aerospike",
+            "ClickHouse",
+            "Kafka",
+            "HAProxy",
+            "Docker"
         ],
         "personal": false,
         "links": [
@@ -145,18 +156,21 @@
     {
         "title": "Avatar Vision",
         "description": {
-            "ko": "ffmpeg 없이 flutter와 rust로 만든 영상 일기 앱.",
-            "en": "A video diary app written in flutter and rust without ffmpeg"
+            "ko": "ffmpeg 없이 Flutter와 Rust로 만든 영상 일기 앱",
+            "en": "A video diary app written in Flutter and Rust without ffmpeg"
         },
         "keyword": [
             "windows",
             "encoding",
             "decoding",
-            "mp4"
+            "mp4",
+            "rust",
+            "ffi"
         ],
         "techStacks": [
-            "flutter",
-            "rust"
+            "Flutter",
+            "Rust",
+            "FFI"
         ],
         "personal": true,
         "links": [
@@ -187,8 +201,8 @@
             "timer"
         ],
         "techStacks": [
-            "flutter",
-            "kotlin"
+            "Flutter",
+            "Kotlin"
         ],
         "personal": true,
         "links": [],
@@ -217,8 +231,8 @@
             "sepolia"
         ],
         "techStacks": [
-            "svelte",
-            "solidity"
+            "Svelte",
+            "Solidity"
         ],
         "personal": true,
         "links": [
@@ -247,9 +261,9 @@
             "chat"
         ],
         "techStacks": [
-            "go",
-            "reactJs",
-            "cassandra"
+            "Go",
+            "React",
+            "Cassandra"
         ],
         "personal": true,
         "links": [],
@@ -275,9 +289,9 @@
             "scraping"
         ],
         "techStacks": [
-            "django",
-            "vueJs",
-            "postgreSQL"
+            "Django",
+            "Vue.js",
+            "PostgreSQL"
         ],
         "personal": true,
         "links": [],
@@ -300,10 +314,12 @@
         },
         "keyword": [
             "android",
-            "jetpack compose"
+            "jetpack compose",
+            "clean architecture"
         ],
         "techStacks": [
-            "kotlin"
+            "Kotlin",
+            "Jetpack Compose"
         ],
         "personal": false,
         "links": [],
@@ -315,7 +331,7 @@
         },
         "article": {
             "ko": "저는 Android 개발자로서 1년 2개월 동안 홀로 안드로이드 클라이언트를 개발하고 운영했습니다. 빠른 템포의 개발 과정에서 앱은 여러 번의 변경을 거쳤고, 그 중에는 몇 가지 크고 중요한 전환도 포함되었습니다.\n\n앱 개발에는 캘린더, cropper 도구, 틴더 같은 스와이프 위젯, 드래그 앤 드롭 기능, 중첩 스크롤링과 탭이 있는 기타 복잡한 위젯 등의 다양한 구성 요소를 Jetpack Compose를 통해 구현했습니다. 클린 아키텍처 원칙을 따라 개발을 진행하고, 이벤트 기반 시스템을 활용했으며, 반응형 프로그래밍을 통합했습니다.\n\n성능 최적화를 위한 네트워크 캐싱을 적용했고, 또한 국제화, 웹뷰 통합, 카메라 기능, PDF 처리, 다중 모듈 시스템, 인증 등도 지원했습니다.\n\n당시 저는 Jetpack Compose와 Android 개발을 정말 즐겼지만, iOS 개발에 사용되는 TCA(The Composable Architecture)에서도 영감을 얻어 앱의 상태 관리를 지속적으로 개선했습니다. 타 개발자들과 협력하면서 프로덕트의 생명 주기를 전체적으로 경험했습니다.",
-            "en": "I developed and ran this project from scratch as an Android developer for fourteen months. During the fast-paced development process, the app went through multiple changes, including several significant pivots.\n\nI believe the app covered a wide range of topics of Jetpack Compose and Android app development. The app included various components like a calendar, cropper, swipe widget like tinder, drag and drop functionality, and other complex widgets with nested scrolling and tabs, among others. The architecture followed clean architecture principles, utilized event-driven systems, and incorporated reactive programming.\n\nI cached network data and images for performance optimization. Additionally, the app supported internationalization, webview integration, camera functionality, PDF handling, a multi-module system, authentication, and more.\n\nAt that time, I really enjoyed working with Jetpack Compose and Android development. I continuously focused on enhancing the app's state management, drawing inspiration from TCA (The Composable Architecture) used in iOS development and the latest Android resources. This project allowed me to experience the entire product lifecycle while collaborating with other role groups at a company level. check out the app on the Play Store using the link below."
+            "en": "I developed and ran this project from scratch as an Android developer for fourteen months. During the fast-paced development process, the app went through multiple changes, including several significant pivots.\n\nI believe the app covered a wide range of topics of Jetpack Compose and Android app development. The app included various components like a calendar, cropper, swipe widget like tinder, drag and drop functionality, and other complex widgets with nested scrolling and tabs, among others. The architecture followed clean architecture principles, utilized event-driven systems, and incorporated reactive programming.\n\nI cached network data and images for performance optimization. Additionally, the app supported internationalization, webview integration, camera functionality, PDF handling, a multi-module system, authentication, and more.\n\nAt that time, I really enjoyed working with Jetpack Compose and Android development. I continuously focused on enhancing the app's state management, drawing inspiration from TCA (The Composable Architecture) used in iOS development and the latest Android resources. This project allowed me to experience the entire product lifecycle while collaborating with other role groups at a company level."
         }
     },
     {
@@ -326,11 +342,15 @@
         },
         "keyword": [
             "android",
-            "jni"
+            "jni",
+            "camera",
+            "c++"
         ],
         "techStacks": [
-            "kotlin",
-            "java"
+            "Kotlin",
+            "Java",
+            "C++",
+            "JNI"
         ],
         "personal": false,
         "links": [],
@@ -357,7 +377,8 @@
             "spring boot"
         ],
         "techStacks": [
-            "java"
+            "Java",
+            "Spring Boot"
         ],
         "personal": false,
         "links": [],
@@ -373,18 +394,19 @@
         }
     },
     {
-        "title": "Fivestar recipe",
+        "title": "Fivestar Recipe",
         "description": {
             "ko": "레시피를 제공하는 웹사이트",
-            "en": "A webstie that provides recipes"
+            "en": "A website that provides recipes"
         },
         "keyword": [
             "web",
             "springMVC"
         ],
         "techStacks": [
-            "java",
-            "vueJs"
+            "Java",
+            "Spring MVC",
+            "Vue.js"
         ],
         "personal": false,
         "links": [],
@@ -410,7 +432,7 @@
             "terminal"
         ],
         "techStacks": [
-            "java"
+            "Java"
         ],
         "personal": false,
         "links": [],
@@ -422,7 +444,7 @@
         },
         "article": {
             "ko": "이건 제가 자바를 배운 후 처음으로 작업한 프로젝트였습니다. 부루마블에서의 기능을 가능한 한 많이 포함하는 것을 목표로했습니다.\n\n각 차례마다 주사위를 굴리고 우주선이나 무인도, 황금열쇠 등의 변수와 함께 게임 말을 이동하여 취할 행동을 결정할 수 있습니다.\n\n처음에 예상했던 것 보다 커버해야하는 시나리오가 훨씬 많아서 당황하면서도 재밌게 개발했던 기억이 있습니다. 팀원은 터미널에 게임판을 그리는데 집중했고 저는 게임의 로직를 개발하는데 집중했습니다.",
-            "en": "This was the first project I worked on after learning Java. I aimed to include as many features from the original game(Monoploy) as possible.\n\nEach turn, you can roll the dice and move the game piece, and then decide what action to take, along with variables such as spaceships, deserted islands, and golden keys.\n\nI remember being surprised and having fun developing it, as there were many more scenarios to cover than I had originally expected. My team member focused on drawing the game board on the terminal, and I focused on developing the logic of the game."
+            "en": "This was the first project I worked on after learning Java. I aimed to include as many features from the original game (Monopoly) as possible.\n\nEach turn, you can roll the dice and move the game piece, and then decide what action to take, along with variables such as spaceships, deserted islands, and golden keys.\n\nI remember being surprised and having fun developing it, as there were many more scenarios to cover than I had originally expected. My team member focused on drawing the game board on the terminal, and I focused on developing the logic of the game."
         }
     }
 ]

--- a/src/components/AiEngineering.tsx
+++ b/src/components/AiEngineering.tsx
@@ -1,0 +1,84 @@
+import { Bot, Zap, Shield, Repeat } from "lucide-react";
+
+interface Props {
+  lang: string;
+}
+
+const stats = [
+  { value: "174", label: { ko: "세션", en: "sessions" } },
+  { value: "248h", label: { ko: "협업 시간", en: "hours" } },
+  { value: "135", label: { ko: "커밋", en: "commits" } },
+  { value: "12+", label: { ko: "커스텀 스킬", en: "custom skills" } },
+];
+
+const approaches = [
+  {
+    icon: Shield,
+    text: {
+      ko: "AI의 거짓 보고를 구조적으로 차단하는 2-Phase 리포트 하니스와 독립 감사 에이전트 설계",
+      en: "Designed 2-phase report harness and independent audit agents to structurally prevent AI hallucinations",
+    },
+  },
+  {
+    icon: Repeat,
+    text: {
+      ko: "반복되는 마찰을 일회성 수정이 아닌 영구 인프라(hook, rule, lint, skill)로 승격",
+      en: "Elevate recurring friction into permanent infrastructure (hooks, rules, lint, skills) instead of one-off fixes",
+    },
+  },
+  {
+    icon: Zap,
+    text: {
+      ko: "병렬 서브에이전트로 탐색·검증·감사를 동시 수행하는 워크플로 구축",
+      en: "Built workflows running parallel sub-agents for exploration, verification, and auditing simultaneously",
+    },
+  },
+];
+
+export default function AiEngineering({ lang }: Props) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm mb-8">
+      <h2 className="flex items-center gap-2 text-xl font-bold text-gray-900 mb-4">
+        <Bot size={20} strokeWidth={1.5} />
+        {lang === "ko" ? "AI 엔지니어링" : "AI Engineering"}
+      </h2>
+
+      <p className="text-gray-700 mb-4 text-[15px]">
+        {lang === "ko"
+          ? "AI를 단순히 사용하는 것이 아니라, AI의 행동 자체를 시스템으로 설계하고 제약합니다."
+          : "I don't just use AI — I engineer its behavior as a system, designing constraints and guardrails."}
+      </p>
+
+      {/* 정량 지표 */}
+      <div className="grid grid-cols-4 gap-2 mb-5">
+        {stats.map((s) => (
+          <div key={s.value} className="text-center">
+            <div className="text-lg font-bold text-gray-900">{s.value}</div>
+            <div className="text-xs text-gray-500">
+              {s.label[lang as "ko" | "en"] ?? s.label.en}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 접근 방식 */}
+      <ul className="space-y-3">
+        {approaches.map((a) => {
+          const Icon = a.icon;
+          return (
+            <li key={a.text.en} className="flex items-start gap-2">
+              <Icon
+                size={16}
+                strokeWidth={1.5}
+                className="text-gray-400 mt-0.5 shrink-0"
+              />
+              <span className="text-sm text-gray-700">
+                {a.text[lang as "ko" | "en"] ?? a.text.en}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -11,7 +11,20 @@ export default function ProjectCard({ project, lang }: Props) {
     <div className="border border-gray-200 p-8 rounded-2xl shadow-sm space-y-6 bg-white w-full max-w-[600px] mx-auto text-[17px] leading-[1.75] text-gray-800 font-sans">
       {/* 타이틀 및 요약 */}
       <div>
-        <h2 className="text-2xl font-bold text-gray-900">{project.title}</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-2xl font-bold text-gray-900">{project.title}</h2>
+          <span
+            className={`text-xs px-2 py-0.5 rounded-full ${
+              project.personal
+                ? "bg-blue-50 text-blue-600 border border-blue-200"
+                : "bg-gray-50 text-gray-500 border border-gray-200"
+            }`}
+          >
+            {project.personal
+              ? lang === "ko" ? "개인" : "Personal"
+              : lang === "ko" ? "회사" : "Company"}
+          </span>
+        </div>
         <p className="mt-2 text-gray-600 leading-relaxed">
           {project.description[lang]}
         </p>
@@ -73,18 +86,25 @@ export default function ProjectCard({ project, lang }: Props) {
             {lang === "ko" ? "관련 링크" : "Links"}
           </h3>
           <ul className="space-y-1">
-            {project.links.map((link, idx) => (
-              <li key={link}>
-                <a
-                  href={link}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-gray-600 hover:text-gray-900 underline text-sm break-all"
-                >
-                  Link {idx + 1}
-                </a>
-              </li>
-            ))}
+            {project.links.map((link) => {
+              const label = link.includes("github.com")
+                ? "GitHub"
+                : link.includes("medium.com")
+                ? "Medium"
+                : new URL(link).hostname.replace("www.", "");
+              return (
+                <li key={link}>
+                  <a
+                    href={link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-gray-600 hover:text-gray-900 underline text-sm"
+                  >
+                    {label}
+                  </a>
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/src/components/TechSummary.tsx
+++ b/src/components/TechSummary.tsx
@@ -1,0 +1,63 @@
+import { Cpu, Server, Smartphone, Globe } from "lucide-react";
+
+interface Props {
+  lang: string;
+}
+
+const categories = [
+  {
+    icon: Smartphone,
+    label: { ko: "모바일", en: "Mobile" },
+    items: ["React Native", "Kotlin", "Jetpack Compose", "Flutter", "Expo"],
+  },
+  {
+    icon: Server,
+    label: { ko: "백엔드 & 인프라", en: "Backend & Infra" },
+    items: ["Go", "Python", "Nginx", "Airflow", "Temporal", "Docker"],
+  },
+  {
+    icon: Cpu,
+    label: { ko: "미디어 & 저수준", en: "Media & Low-level" },
+    items: ["OpenGL", "OpenCV", "Rust", "C++", "WebRTC", "MediaCodec"],
+  },
+  {
+    icon: Globe,
+    label: { ko: "웹", en: "Web" },
+    items: ["TypeScript", "React", "Next.js", "Svelte", "Vue.js"],
+  },
+];
+
+export default function TechSummary({ lang }: Props) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm mb-8">
+      <h2 className="text-xl font-bold text-gray-900 mb-4">
+        {lang === "ko" ? "기술 스택" : "Tech Stack"}
+      </h2>
+      <div className="grid grid-cols-2 gap-4">
+        {categories.map((cat) => {
+          const Icon = cat.icon;
+          return (
+            <div key={cat.label.en}>
+              <div className="flex items-center gap-2 mb-2">
+                <Icon size={16} strokeWidth={1.5} className="text-gray-500" />
+                <span className="text-sm font-semibold text-gray-700">
+                  {cat.label[lang as "ko" | "en"] ?? cat.label.en}
+                </span>
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {cat.items.map((item) => (
+                  <span
+                    key={item}
+                    className="bg-gray-100 text-gray-600 text-xs px-2 py-0.5 rounded-full"
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -3,11 +3,14 @@ import { useSearchParams } from "react-router-dom";
 import { useMeta } from "../hooks/useMeta";
 import Experience from "../components/Experience";
 import Header from "../components/Header";
+import TechSummary from "../components/TechSummary";
 import { Mail, Github } from "lucide-react";
+import type { AboutTranslations, ExperienceGroup } from "../types";
 
 export default function About() {
-  const [translations, setTranslations] = useState<any>(null);
-  const [experiences, setExperiences] = useState<any[]>([]);
+  const [translations, setTranslations] = useState<AboutTranslations | null>(null);
+  const [experiences, setExperiences] = useState<ExperienceGroup[]>([]);
+  const [error, setError] = useState(false);
   const [searchParams] = useSearchParams();
   const lang = searchParams.get("lang") || "ko";
 
@@ -28,28 +31,39 @@ export default function About() {
           fetch("/resume/assets/experience.json"),
         ]);
 
+        if (!aboutRes.ok || !experienceRes.ok) throw new Error("Failed");
+
         const aboutData = await aboutRes.json();
         const experienceData = await experienceRes.json();
 
         setTranslations(aboutData.translations);
         setExperiences(experienceData.experiences);
-      } catch (error) {
-        console.error("Error loading data:", error);
+      } catch {
+        setError(true);
       }
     };
 
     loadData();
   }, []);
 
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-gray-500">
+          {lang === "ko" ? "데이터를 불러올 수 없습니다." : "Failed to load data."}
+        </p>
+      </div>
+    );
+  }
+
   if (!translations) {
-    return <br />;
+    return <div className="min-h-screen" />;
   }
 
   return (
     <div className="px-4 py-6 w-full max-w-[600px] mx-auto font-sans text-gray-800 leading-relaxed text-[17px]">
       <Header />
 
-      {/* 프로필 카드 */}
       <div className="bg-white border border-gray-200 rounded-2xl p-6 shadow-sm mb-8">
         <h1 className="text-2xl font-bold mb-4 text-gray-900">
           {translations.helloText[lang]}
@@ -78,6 +92,8 @@ export default function About() {
           <p>{translations.projectText[lang]}</p>
         </div>
       </div>
+
+      <TechSummary lang={lang} />
 
       <Experience experiences={experiences} lang={lang} />
     </div>

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -4,6 +4,7 @@ import { useMeta } from "../hooks/useMeta";
 import Experience from "../components/Experience";
 import Header from "../components/Header";
 import TechSummary from "../components/TechSummary";
+import AiEngineering from "../components/AiEngineering";
 import { Mail, Github } from "lucide-react";
 import type { AboutTranslations, ExperienceGroup } from "../types";
 
@@ -94,6 +95,8 @@ export default function About() {
       </div>
 
       <TechSummary lang={lang} />
+
+      <AiEngineering lang={lang} />
 
       <Experience experiences={experiences} lang={lang} />
     </div>

--- a/src/routes/home.tsx
+++ b/src/routes/home.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom"; // react-router-dom 훅
+import { useSearchParams } from "react-router-dom";
 import Header from "../components/Header";
 import ProjectCard from "../components/ProjectCard";
 import { useMeta } from "../hooks/useMeta";
+import type { Project } from "../types";
+
 export default function Home() {
-  const [projects, setProjects] = useState<any[]>([]);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [error, setError] = useState(false);
   const [searchParams] = useSearchParams();
   const lang = searchParams.get("lang") || "ko";
 
@@ -12,18 +15,20 @@ export default function Home() {
     { title: "Projects - HanGuk Shin" },
     { name: "description", content: "Resume of HanGuk Shin." },
     { name: "keywords", content: "Dev, Resume, HanGuk Shin" },
-    { property: "og:title", content: "About - HanGuk Shin" },
+    { property: "og:title", content: "Projects - HanGuk Shin" },
     { property: "og:description", content: "Resume of HanGuk Shin." },
     { property: "og:type", content: "website" },
   ]);
+
   useEffect(() => {
     const loadJson = async () => {
       try {
         const response = await fetch("/resume/assets/projects.json");
+        if (!response.ok) throw new Error("Failed to load");
         const data = await response.json();
         setProjects(data);
-      } catch (error) {
-        console.error("Error loading JSON:", error);
+      } catch {
+        setError(true);
       }
     };
     loadJson();
@@ -32,16 +37,22 @@ export default function Home() {
   const handleNavClick = (projectTitle: string) => {
     const element = document.getElementById(projectTitle);
     if (element) {
-      element.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   };
 
+  if (error) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
+        <p className="text-gray-500">
+          {lang === "ko" ? "데이터를 불러올 수 없습니다." : "Failed to load data."}
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-gray-100">
-      {/* 고정된 내비 */}
       <div
         className="fixed left-0 top-0 w-64 h-full bg-gray-100 shadow-lg overflow-y-auto p-4 z-10
                 hidden lg:block"
@@ -51,16 +62,24 @@ export default function Home() {
             <div key={project.title}>
               <button
                 onClick={() => handleNavClick(project.title)}
-                className="text-gray-600 hover:text-blue-600 transition-colors text-left w-full"
+                className="text-gray-600 hover:text-blue-600 transition-colors text-left w-full text-sm"
               >
+                {project.personal && (
+                  <span className="text-xs text-blue-500 mr-1">●</span>
+                )}
                 {project.title}
               </button>
             </div>
           ))}
+          <div className="mt-4 pt-4 border-t border-gray-200">
+            <div className="flex items-center gap-2 text-xs text-gray-400">
+              <span className="text-blue-500">●</span>
+              <span>{lang === "ko" ? "개인 프로젝트" : "Personal"}</span>
+            </div>
+          </div>
         </div>
       </div>
 
-      {/* 메인 콘텐츠 - 전체 화면 너비 기준 중앙 정렬 */}
       <div className="flex justify-center bg-gray-100 min-h-screen">
         <div className="px-4 py-6 max-w-3xl mx-auto font-sans text-gray-800 w-[600px] leading-relaxed text-[17px]">
           <Header />

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,8 +20,25 @@ export interface Project {
   date: {
     startMonth: number;
     startYear: number;
-    endMonth: number;
-    endYear: number;
+    endMonth: number | null;
+    endYear: number | null;
   };
   article: Record<string, string>;
+}
+
+export interface AboutTranslations {
+  helloText: Record<string, string>;
+  emailText: string;
+  githubText: string;
+  interestedText: Record<string, string>;
+  backgroundText: Record<string, string>;
+  projectText: Record<string, string>;
+  linkText: string;
+  contributingText: Record<string, string>;
+  contributingMinimp4Text: Record<string, string>;
+  contributingNokhwaText: Record<string, string>;
+  linkMinimp4Text: string;
+  linkNokhwaText: string;
+  linkOpenGlTextEn: string;
+  linkOpenGlTextKo: string;
 }


### PR DESCRIPTION
## Summary
- **콘텐츠 강화**: REVITA 프로젝트에 서버 인프라 상세 추가 (10+ 서비스, MQTT/Airflow/Temporal, GCP VM 운영), 기술 스택 정규화
- **코드 품질**: `useState<any>` → 실제 타입 적용, fetch 에러 시 fallback UI 추가
- **UX 개선**: About 페이지에 TechSummary 4분류 그리드, 프로젝트 카드에 개인/회사 뱃지, 사이드바 범례, 링크 자동 라벨 (GitHub/Medium 감지)

## Changes
| 파일 | 변경 |
|------|------|
| `public/assets/projects.json` | REVITA 설명 강화, 기술스택 추가, 대소문자 정규화 |
| `public/assets/about.json` | 프로필 텍스트 업데이트 (크로스플랫폼+인프라 역량) |
| `src/types.ts` | `AboutTranslations` 인터페이스 추가, `endMonth/endYear` nullable |
| `src/routes/home.tsx` | `Project[]` 타입, 에러 UI, 사이드바 개인/회사 구분 |
| `src/routes/about.tsx` | 타입 적용, 에러 UI, TechSummary 통합 |
| `src/components/TechSummary.tsx` | 신규 — 4분류 기술 스택 그리드 |
| `src/components/ProjectCard.tsx` | 개인/회사 뱃지, 링크 라벨 개선 |

## Test plan
- [ ] `npm run build` 성공 확인 (tsc + vite)
- [ ] 로컬 `npm run dev`로 `/resume/` 및 `/resume/about` 렌더링 확인
- [ ] 한국어/영어 토글 정상 동작
- [ ] 모바일 뷰포트에서 레이아웃 깨짐 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)